### PR TITLE
Fix tests in the "signed" directory

### DIFF
--- a/signed/sign_test.go
+++ b/signed/sign_test.go
@@ -1,14 +1,22 @@
 package signed
 
 import (
+	"encoding/pem"
 	"testing"
 
 	"github.com/endophage/gotuf/data"
-	"github.com/endophage/gotuf/keys"
+)
+
+const (
+	testKeyPEM1 = "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAnKuXZeefa2LmgxaL5NsM\nzKOHNe+x/nL6ik+lDBCTV6OdcwAhHQS+PONGhrChIUVR6Vth3hUCrreLzPO73Oo5\nVSCuRJ53UronENl6lsa5mFKP8StYLvIDITNvkoT3j52BJIjyNUK9UKY9As2TNqDf\nBEPIRp28ev/NViwGOEkBu2UAbwCIdnDXm8JQErCZA0Ydm7PKGgjLbFsFGrVzqXHK\n6pdzJXlhr9yap3UpgQ/iO9JtoEYB2EXsnSrPc9JRjR30bNHHtnVql3fvinXrAEwq\n3xmN4p+R4VGzfdQN+8Kl/IPjqWB535twhFYEG/B7Ze8IwbygBjK3co/KnOPqMUrM\nBI8ztvPiogz+MvXb8WvarZ6TMTh8ifZI96r7zzqyzjR1hJulEy3IsMGvz8XS2J0X\n7sXoaqszEtXdq5ef5zKVxkiyIQZcbPgmpHLq4MgfdryuVVc/RPASoRIXG4lKaTJj\n1ANMFPxDQpHudCLxwCzjCb+sVa20HBRPTnzo8LSZkI6jAgMBAAE=\n-----END PUBLIC KEY-----"
+	testKeyID1  = "51324b59d4888faa91219ebbe5a3876bb4efb21f0602ddf363cd4c3996ded3d4"
+
+	testKeyPEM2 = "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEArvqUPYb6JJROPJQglPTj\n5uDrsxQKl34Mo+3pSlBVuD6puE4lDnG649a2YksJy+C8ZIPJgokn5w+C3alh+dMe\nzbdWHHxrY1h9CLpYz5cbMlE16303ubkt1rvwDqEezG0HDBzPaKj4oP9YJ9x7wbsq\ndvFcy+Qc3wWd7UWcieo6E0ihbJkYcY8chRXVLg1rL7EfZ+e3bq5+ojA2ECM5JqzZ\nzgDpqCv5hTCYYZp72MZcG7dfSPAHrcSGIrwg7whzz2UsEtCOpsJTuCl96FPN7kAu\n4w/WyM3+SPzzr4/RQXuY1SrLCFD8ebM2zHt/3ATLhPnGmyG5I0RGYoegFaZ2AViw\nlqZDOYnBtgDvKP0zakMtFMbkh2XuNBUBO7Sjs0YcZMjLkh9gYUHL1yWS3Aqus1Lw\nlI0gHS22oyGObVBWkZEgk/Foy08sECLGao+5VvhmGpfVuiz9OKFUmtPVjWzRE4ng\niekEu4drSxpH41inLGSvdByDWLpcTvWQI9nkgclh3AT/AgMBAAE=\n-----END PUBLIC KEY-----"
+	testKeyID2  = "26f2f5c0fbfa98823bf1ad39d5f3b32575895793baf80f1df675597d5b95dba8"
 )
 
 type MockCryptoService struct {
-	testKey keys.PublicKey
+	testKey data.PublicKey
 }
 
 func (mts *MockCryptoService) Sign(keyIDs []string, _ []byte) ([]data.Signature, error) {
@@ -19,12 +27,12 @@ func (mts *MockCryptoService) Sign(keyIDs []string, _ []byte) ([]data.Signature,
 	return sigs, nil
 }
 
-func (mts *MockCryptoService) Create() (*keys.PublicKey, error) {
+func (mts *MockCryptoService) Create(_ string) (*data.PublicKey, error) {
 	return &mts.testKey, nil
 }
 
-func (mts *MockCryptoService) PublicKeys(keyIDs ...string) (map[string]*keys.PublicKey, error) {
-	keys := map[string]*keys.PublicKey{"testID": &mts.testKey}
+func (mts *MockCryptoService) PublicKeys(keyIDs ...string) (map[string]*data.PublicKey, error) {
+	keys := map[string]*data.PublicKey{"testID": &mts.testKey}
 	return keys, nil
 }
 
@@ -32,8 +40,10 @@ var _ CryptoService = &MockCryptoService{}
 
 // Test signing and ensure the expected signature is added
 func TestBasicSign(t *testing.T) {
+	testKey, _ := pem.Decode([]byte(testKeyPEM1))
+	k := data.NewPublicKey("rsa", testKey.Bytes)
 	signer := Signer{&MockCryptoService{
-		testKey: keys.PublicKey{ID: "testID"},
+		testKey: *k,
 	}}
 	key, err := signer.Create("root")
 	if err != nil {
@@ -47,7 +57,7 @@ func TestBasicSign(t *testing.T) {
 		t.Fatalf("Incorrect number of signatures: %d", len(testData.Signatures))
 	}
 
-	if testData.Signatures[0].KeyID != "testID" {
+	if testData.Signatures[0].KeyID != testKeyID1 {
 		t.Fatalf("Wrong signature ID returned: %s", testData.Signatures[0].KeyID)
 	}
 
@@ -57,20 +67,21 @@ func TestBasicSign(t *testing.T) {
 // for the key (N.B. MockCryptoService.Sign will still be called again, but Signer.Sign
 // should be cleaning previous signatures by the KeyID when asked to sign again)
 func TestReSign(t *testing.T) {
+	testKey, _ := pem.Decode([]byte(testKeyPEM1))
+	k := data.NewPublicKey("rsa", testKey.Bytes)
 	signer := Signer{&MockCryptoService{
-		testKey: keys.PublicKey{},
+		testKey: *k,
 	}}
-	key := keys.PublicKey{ID: "testID"}
 	testData := data.Signed{}
 
-	signer.Sign(&testData, &key)
-	signer.Sign(&testData, &key)
+	signer.Sign(&testData, k)
+	signer.Sign(&testData, k)
 
 	if len(testData.Signatures) != 1 {
 		t.Fatalf("Incorrect number of signatures: %d", len(testData.Signatures))
 	}
 
-	if testData.Signatures[0].KeyID != "testID" {
+	if testData.Signatures[0].KeyID != testKeyID1 {
 		t.Fatalf("Wrong signature ID returned: %s", testData.Signatures[0].KeyID)
 	}
 
@@ -78,19 +89,21 @@ func TestReSign(t *testing.T) {
 
 func TestMultiSign(t *testing.T) {
 	signer := Signer{&MockCryptoService{}}
-	key := keys.PublicKey{ID: "testID1"}
 	testData := data.Signed{}
 
-	signer.Sign(&testData, &key)
+	testKey, _ := pem.Decode([]byte(testKeyPEM1))
+	key := data.NewPublicKey("rsa", testKey.Bytes)
+	signer.Sign(&testData, key)
 
-	key = keys.PublicKey{ID: "testID2"}
-	signer.Sign(&testData, &key)
+	testKey, _ = pem.Decode([]byte(testKeyPEM2))
+	key = data.NewPublicKey("rsa", testKey.Bytes)
+	signer.Sign(&testData, key)
 
 	if len(testData.Signatures) != 2 {
 		t.Fatalf("Incorrect number of signatures: %d", len(testData.Signatures))
 	}
 
-	keyIDs := map[string]struct{}{"testID1": struct{}{}, "testID2": struct{}{}}
+	keyIDs := map[string]struct{}{testKeyID1: struct{}{}, testKeyID2: struct{}{}}
 	for _, sig := range testData.Signatures {
 		if _, ok := keyIDs[sig.KeyID]; !ok {
 			t.Fatalf("Got a signature we didn't expect: %s", sig.KeyID)
@@ -100,8 +113,10 @@ func TestMultiSign(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	testKey, _ := pem.Decode([]byte(testKeyPEM1))
+	k := data.NewPublicKey("rsa", testKey.Bytes)
 	signer := Signer{&MockCryptoService{
-		testKey: keys.PublicKey{ID: "testID"},
+		testKey: *k,
 	}}
 
 	key, err := signer.Create("root")
@@ -109,7 +124,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if key.ID != "testID" {
-		t.Fatalf("Expected key ID not found: %s", key.ID)
+	if key.ID() != testKeyID1 {
+		t.Fatalf("Expected key ID not found: %s", key.ID())
 	}
 }

--- a/signed/verifiers_test.go
+++ b/signed/verifiers_test.go
@@ -1,10 +1,10 @@
 package signed
 
 import (
-	"crypto"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
+	_ "crypto"
+	_ "crypto/rsa"
+	_ "crypto/sha256"
+	_ "crypto/x509"
 	"testing"
 )
 


### PR DESCRIPTION
Main changes:
- Update tests to use data.PublicKey instead of outdated keys.PublicKey
- Fetch the key ID with the ID() method instead of trying to access the
  ID field directly (it's no longer exported).
- Use real keys in sign_test. Now that the key IDs can't be manipulated
  directly, the test can't just set arbitrary key IDs.
- Fix timestamp time/string confusion.
- verify_test needs a Name in the roles map, and also needs to use
  TUFTypes to look up the corresponding type for a role.
