### PR TITLE
Fix ED25519 keys/signatures

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -15,14 +15,17 @@ import (
 
 const (
 	defaultHashAlgorithm = "sha256"
-	EDDSASignature       = "eddsa"
-	RSAPSSSignature      = "rsapss"
-	ECDSASignature       = "ecdsa"
-	RSAKey               = "rsa"
-	RSAx509Key           = "rsa-x509"
-	ECDSAKey             = "ecdsa"
-	ECDSAx509Key         = "ecdsa-x509"
-	PyCryptoSignature    = "pycrypto-pkcs#1 pss"
+
+	EDDSASignature    = "eddsa"
+	RSAPSSSignature   = "rsapss"
+	ECDSASignature    = "ecdsa"
+	PyCryptoSignature = "pycrypto-pkcs#1 pss"
+
+	ED25519Key   = "ed25519"
+	RSAKey       = "rsa"
+	RSAx509Key   = "rsa-x509"
+	ECDSAKey     = "ecdsa"
+	ECDSAx509Key = "ecdsa-x509"
 )
 
 var TUFTypes = map[string]string{

--- a/signed/ed25519.go
+++ b/signed/ed25519.go
@@ -37,7 +37,7 @@ func (trust *Ed25519) Sign(keyIDs []string, toSign []byte) ([]data.Signature, er
 		sig := ed25519.Sign(&priv, toSign)
 		signatures = append(signatures, data.Signature{
 			KeyID:     kID,
-			Method:    "ED25519",
+			Method:    data.EDDSASignature,
 			Signature: sig[:],
 		})
 	}
@@ -50,8 +50,8 @@ func (trust *Ed25519) Create(role string) (*data.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	public := data.NewPublicKey("ED25519", pub[:])
-	private := data.NewPrivateKey("ED25519", pub[:], priv[:])
+	public := data.NewPublicKey(data.ED25519Key, pub[:])
+	private := data.NewPrivateKey(data.ED25519Key, pub[:], priv[:])
 	trust.addKey(private)
 	return public, nil
 }

--- a/store/httpstore_test.go
+++ b/store/httpstore_test.go
@@ -68,13 +68,13 @@ func TestPyCryptoRSAPSSCompat(t *testing.T) {
 	//privPem := "-----BEGIN RSA PRIVATE KEY-----\nMIIG4wIBAAKCAYEAnKuXZeefa2LmgxaL5NsMzKOHNe+x/nL6ik+lDBCTV6OdcwAh\nHQS+PONGhrChIUVR6Vth3hUCrreLzPO73Oo5VSCuRJ53UronENl6lsa5mFKP8StY\nLvIDITNvkoT3j52BJIjyNUK9UKY9As2TNqDfBEPIRp28ev/NViwGOEkBu2UAbwCI\ndnDXm8JQErCZA0Ydm7PKGgjLbFsFGrVzqXHK6pdzJXlhr9yap3UpgQ/iO9JtoEYB\n2EXsnSrPc9JRjR30bNHHtnVql3fvinXrAEwq3xmN4p+R4VGzfdQN+8Kl/IPjqWB5\n35twhFYEG/B7Ze8IwbygBjK3co/KnOPqMUrMBI8ztvPiogz+MvXb8WvarZ6TMTh8\nifZI96r7zzqyzjR1hJulEy3IsMGvz8XS2J0X7sXoaqszEtXdq5ef5zKVxkiyIQZc\nbPgmpHLq4MgfdryuVVc/RPASoRIXG4lKaTJj1ANMFPxDQpHudCLxwCzjCb+sVa20\nHBRPTnzo8LSZkI6jAgMBAAECggGAdzyI7z/HLt2IfoAsXDLynNRgVYZluzgawiU3\ngeUjnnGhpSKWERXJC2IWDPBk0YOGgcnQxErNTdfXiFZ/xfRlSgqjVwob2lRe4w4B\npLr+CZXcgznv1VrPUvdolOSp3R2Mahfn7u0qVDUQ/g8jWVI6KW7FACmQhzQkPM8o\ntLGrpcmK+PA465uaHKtYccEB02ILqrK8v++tknv7eIZczrsSKlS1h/HHjSaidYxP\n2DAUiF7wnChrwwQEvuEUHhwVgQcoDMBoow0zwHdbFiFO2ZT54H2oiJWLhpR/x6RK\ngM1seqoPH2sYErPJACMcYsMtF4Tx7b5c4WSj3vDCGb+jeqnNS6nFC3aMnv75mUS2\nYDPU1heJFd8pNHVf0RDejLZZUiJSnXf3vpOxt9Xv2+4He0jeMfLV7zX0mO2Ni3MJ\nx6PiVy4xerHImOuuHzSla5crOq2ECiAxd1wEOFDRD2LRHzfhpk1ghiA5xA1qwc7Z\neRnkVfoy6PPZ4lZakZTm0p8YCQURAoHBAMUIC/7vnayLae7POmgy+np/ty7iMfyd\nV1eO6LTO21KAaGGlhaY26WD/5LcG2FUgc5jKKahprGrmiNLzLUeQPckJmuijSEVM\nl/4DlRvCo867l7fLaVqYzsQBBdeGIFNiT+FBOd8atff87ZBEfH/rXbDi7METD/VR\n4TdblnCsKYAXEJUdkw3IK7SUGERiQZIwKXrH/Map4ibDrljJ71iCgEureU0DBwcg\nwLftmjGMISoLscdRxeubX5uf/yxtHBJeRwKBwQDLjzHhb4gNGdBHUl4hZPAGCq1V\nLX/GpfoOVObW64Lud+tI6N9GNua5/vWduL7MWWOzDTMZysganhKwsJCY5SqAA9p0\nb6ohusf9i1nUnOa2F2j+weuYPXrTYm+ZrESBBdaEJPuj3R5YHVujrBA9Xe0kVOe3\nne151A+0xJOI3tX9CttIaQAsXR7cMDinkDITw6i7X4olRMPCSixHLW97cDsVDRGt\necO1d4dP3OGscN+vKCoL6tDKDotzWHYPwjH47sUCgcEAoVI8WCiipbKkMnaTsNsE\ngKXvO0DSgq3k5HjLCbdQldUzIbgfnH7bSKNcBYtiNxjR7OihgRW8qO5GWsnmafCs\n1dy6a/2835id3cnbHRaZflvUFhVDFn2E1bCsstFLyFn3Y0w/cO9yzC/X5sZcVXRF\nit3R0Selakv3JZckru4XMJwx5JWJYMBjIIAc+miknWg3niL+UT6pPun65xG3mXWI\nS+yC7c4rw+dKQ44UMLs2MDHRBoxqi8T0W/x9NkfDszpjAoHAclH7S4ZdvC3RIR0L\nLGoJuvroGbwx1JiGdOINuooNwGuswge2zTIsJi0gN/H3hcB2E6rIFiYid4BrMrwW\nmSeq1LZVS6siu0qw4p4OVy+/CmjfWKQD8j4k6u6PipiK6IMk1JYIlSCr2AS04JjT\njgNgGVVtxVt2cUM9huIXkXjEaRZdzK7boA60NCkIyGJdHWh3LLQdW4zg/A64C0lj\nIMoJBGuQkAKgfRuh7KI6Q6Qom7BM3OCFXdUJUEBQHc2MTyeZAoHAJdBQGBn1RFZ+\nn75AnbTMZJ6Twp2fVjzWUz/+rnXFlo87ynA18MR2BzaDST4Bvda29UBFGb32Mux9\nOHukqLgIE5jDuqWjy4B5eCoxZf/OvwlgXkX9+gprGR3axn/PZBFPbFB4ZmjbWLzn\nbocn7FJCXf+Cm0cMmv1jIIxej19MUU/duq9iq4RkHY2LG+KrSEQIUVmImCftXdN3\n/qNP5JetY0eH6C+KRc8JqDB0nvbqZNOgYXOfYXo/5Gk8XIHTFihm\n-----END RSA PRIVATE KEY-----"
 	testStr := "The quick brown fox jumps over the lazy dog."
 	sigHex := "4e05ee9e435653549ac4eddbc43e1a6868636e8ea6dbec2564435afcb0de47e0824cddbd88776ddb20728c53ecc90b5d543d5c37575fda8bd0317025fc07de62ee8084b1a75203b1a23d1ef4ac285da3d1fc63317d5b2cf1aafa3e522acedd366ccd5fe4a7f02a42922237426ca3dc154c57408638b9bfaf0d0213855d4e9ee621db204151bcb13d4dbb18f930ec601469c992c84b14e9e0b6f91ac9517bb3b749dd117e1cbac2e4acb0e549f44558a2005898a226d5b6c8b9291d7abae0d9e0a16858b89662a085f74a202deb867acab792bdbd2c36731217caea8b17bd210c29b890472f11e5afdd1dd7b69004db070e04201778f2c49f5758643881403d45a58d08f51b5c63910c6185892f0b590f191d760b669eff2464456f130239bba94acf54a0cb98f6939ff84ae26a37f9b890be259d9b5d636f6eb367b53e895227d7d79a3a88afd6d28c198ee80f6527437c5fbf63accb81709925c4e03d1c9eaee86f58e4bd1c669d6af042dbd412de0d13b98b1111e2fadbe34b45de52125e9a"
-	k := data.NewPublicKey("RSA", []byte(pubPem))
+	k := data.NewPublicKey(data.RSAKey, []byte(pubPem))
 
 	sigBytes, err := hex.DecodeString(sigHex)
 	if err != nil {
 		t.Fatal(err)
 	}
-	v := signed.RSAPSSVerifier{}
+	v := signed.RSAPyCryptoVerifier{}
 	err = v.Verify(k, sigBytes, []byte(testStr))
 	if err != nil {
 		t.Fatal(err)
@@ -88,11 +88,11 @@ func TestPyNaCled25519Compat(t *testing.T) {
 	sigHex := "166e7013e48f26dccb4e68fe4cf558d1cd3af902f8395534336a7f8b4c56588694aa3ac671767246298a59d5ef4224f02c854f41bfcfe70241db4be1546d6a00"
 
 	pub, _ := hex.DecodeString(pubHex)
-	k := data.NewPublicKey("ED25519", pub)
+	k := data.NewPublicKey(data.ED25519Key, pub)
 
 	sigBytes, _ := hex.DecodeString(sigHex)
 
-	err := signed.Verifiers["ED25519"].Verify(k, sigBytes, []byte(testStr))
+	err := signed.Verifiers[data.EDDSASignature].Verify(k, sigBytes, []byte(testStr))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The signature method string used by the signer was not consistent with
the method string expected by the verifier. This was breaking
verify_test.go.

Fix by using data.EDDSASignature consistently. Also add data.ED25519Key
for consistency.

Signed-off-by: Aaron Lehmann aaron.lehmann@docker.com
