### PR TITLE
Split up Key interface into PublicKey and PrivateKey interfaces

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -125,13 +125,13 @@ func NewFileMeta(r io.Reader, hashAlgorithms ...string) (FileMeta, error) {
 }
 
 type Delegations struct {
-	Keys  map[string]*PublicKey `json:"keys"`
-	Roles []*Role               `json:"roles"`
+	Keys  map[string]PublicKey `json:"keys"`
+	Roles []*Role              `json:"roles"`
 }
 
 func NewDelegations() *Delegations {
 	return &Delegations{
-		Keys:  make(map[string]*PublicKey),
+		Keys:  make(map[string]PublicKey),
 		Roles: make([]*Role, 0),
 	}
 }

--- a/keys/db.go
+++ b/keys/db.go
@@ -18,17 +18,17 @@ var (
 
 type KeyDB struct {
 	roles map[string]*data.Role
-	keys  map[string]data.Key
+	keys  map[string]data.PublicKey
 }
 
 func NewDB() *KeyDB {
 	return &KeyDB{
 		roles: make(map[string]*data.Role),
-		keys:  make(map[string]data.Key),
+		keys:  make(map[string]data.PublicKey),
 	}
 }
 
-func (db *KeyDB) AddKey(k data.Key) {
+func (db *KeyDB) AddKey(k data.PublicKey) {
 	db.keys[k.ID()] = k
 }
 
@@ -51,7 +51,7 @@ func (db *KeyDB) AddRole(r *data.Role) error {
 	return nil
 }
 
-func (db *KeyDB) GetKey(id string) data.Key {
+func (db *KeyDB) GetKey(id string) data.PublicKey {
 	return db.keys[id]
 }
 

--- a/signed/ed25519.go
+++ b/signed/ed25519.go
@@ -10,17 +10,17 @@ import (
 
 // Ed25519 implements a simple in memory cryptosystem for ED25519 keys
 type Ed25519 struct {
-	keys map[string]*data.PrivateKey
+	keys map[string]data.PrivateKey
 }
 
 func NewEd25519() *Ed25519 {
 	return &Ed25519{
-		make(map[string]*data.PrivateKey),
+		make(map[string]data.PrivateKey),
 	}
 }
 
 // addKey allows you to add a private key
-func (e *Ed25519) addKey(k *data.PrivateKey) {
+func (e *Ed25519) addKey(k data.PrivateKey) {
 	e.keys[k.ID()] = k
 }
 
@@ -45,7 +45,7 @@ func (e *Ed25519) Sign(keyIDs []string, toSign []byte) ([]data.Signature, error)
 
 }
 
-func (e *Ed25519) Create(role string, algorithm data.KeyAlgorithm) (data.Key, error) {
+func (e *Ed25519) Create(role string, algorithm data.KeyAlgorithm) (data.PublicKey, error) {
 	if algorithm != data.ED25519Key {
 		return nil, errors.New("only ED25519 supported by this cryptoservice")
 	}
@@ -60,8 +60,8 @@ func (e *Ed25519) Create(role string, algorithm data.KeyAlgorithm) (data.Key, er
 	return public, nil
 }
 
-func (e *Ed25519) PublicKeys(keyIDs ...string) (map[string]*data.PublicKey, error) {
-	k := make(map[string]*data.PublicKey)
+func (e *Ed25519) PublicKeys(keyIDs ...string) (map[string]data.PublicKey, error) {
+	k := make(map[string]data.PublicKey)
 	for _, kID := range keyIDs {
 		if key, ok := e.keys[kID]; ok {
 			k[kID] = data.PublicKeyFromPrivate(key)
@@ -70,6 +70,6 @@ func (e *Ed25519) PublicKeys(keyIDs ...string) (map[string]*data.PublicKey, erro
 	return k, nil
 }
 
-func (e *Ed25519) GetKey(keyID string) data.Key {
+func (e *Ed25519) GetKey(keyID string) data.PublicKey {
 	return data.PublicKeyFromPrivate(e.keys[keyID])
 }

--- a/signed/interface.go
+++ b/signed/interface.go
@@ -20,10 +20,10 @@ type KeyService interface {
 	// the private key into the appropriate signing service.
 	// The role isn't currently used for anything, but it's here to support
 	// future features
-	Create(role string, algorithm data.KeyAlgorithm) (data.Key, error)
+	Create(role string, algorithm data.KeyAlgorithm) (data.PublicKey, error)
 
 	// GetKey retrieves the public key if present, otherwise it returns nil
-	GetKey(keyID string) data.Key
+	GetKey(keyID string) data.PublicKey
 
 	// RemoveKey deletes the specified key
 	RemoveKey(keyID string) error
@@ -40,5 +40,5 @@ type CryptoService interface {
 // of this interface should verify signatures for one and only one
 // signing scheme.
 type Verifier interface {
-	Verify(key data.Key, sig []byte, msg []byte) error
+	Verify(key data.PublicKey, sig []byte, msg []byte) error
 }

--- a/signed/sign.go
+++ b/signed/sign.go
@@ -7,7 +7,7 @@ import (
 
 // Sign takes a data.Signed and a key, calculated and adds the signature
 // to the data.Signed
-func Sign(service CryptoService, s *data.Signed, keys ...data.Key) error {
+func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
 	logrus.Debugf("sign called with %d keys", len(keys))
 	signatures := make([]data.Signature, 0, len(s.Signatures)+1)
 	keyIDMemb := make(map[string]struct{})

--- a/signed/sign_test.go
+++ b/signed/sign_test.go
@@ -27,13 +27,13 @@ func (mts *MockCryptoService) Sign(keyIDs []string, _ []byte) ([]data.Signature,
 	return sigs, nil
 }
 
-func (mts *MockCryptoService) Create(_ string, _ data.KeyAlgorithm) (data.Key, error) {
-	return &mts.testKey, nil
+func (mts *MockCryptoService) Create(_ string, _ data.KeyAlgorithm) (data.PublicKey, error) {
+	return mts.testKey, nil
 }
 
-func (mts *MockCryptoService) GetKey(keyID string) data.Key {
+func (mts *MockCryptoService) GetKey(keyID string) data.PublicKey {
 	if keyID == "testID" {
-		return &mts.testKey
+		return mts.testKey
 	}
 	return nil
 }
@@ -48,7 +48,7 @@ var _ CryptoService = &MockCryptoService{}
 func TestBasicSign(t *testing.T) {
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	k := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	mockCryptoService := &MockCryptoService{testKey: *k}
+	mockCryptoService := &MockCryptoService{testKey: k}
 	key, err := mockCryptoService.Create("root", data.ED25519Key)
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +73,7 @@ func TestBasicSign(t *testing.T) {
 func TestReSign(t *testing.T) {
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	k := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	mockCryptoService := &MockCryptoService{testKey: *k}
+	mockCryptoService := &MockCryptoService{testKey: k}
 	testData := data.Signed{}
 
 	Sign(mockCryptoService, &testData, k)
@@ -117,7 +117,7 @@ func TestMultiSign(t *testing.T) {
 func TestCreate(t *testing.T) {
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	k := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	mockCryptoService := &MockCryptoService{testKey: *k}
+	mockCryptoService := &MockCryptoService{testKey: k}
 
 	key, err := mockCryptoService.Create("root", data.ED25519Key)
 

--- a/signed/verifiers.go
+++ b/signed/verifiers.go
@@ -46,7 +46,7 @@ func RegisterVerifier(algorithm data.SigAlgorithm, v Verifier) {
 
 type Ed25519Verifier struct{}
 
-func (v Ed25519Verifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v Ed25519Verifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	var sigBytes [ed25519.SignatureSize]byte
 	if len(sig) != len(sigBytes) {
 		logrus.Infof("signature length is incorrect, must be %d, was %d.", ed25519.SignatureSize, len(sig))
@@ -79,7 +79,7 @@ func verifyPSS(key interface{}, digest, sig []byte) error {
 	return nil
 }
 
-func getRSAPubKey(key data.Key) (crypto.PublicKey, error) {
+func getRSAPubKey(key data.PublicKey) (crypto.PublicKey, error) {
 	algorithm := key.Algorithm()
 	var pubKey crypto.PublicKey
 
@@ -115,7 +115,7 @@ func getRSAPubKey(key data.Key) (crypto.PublicKey, error) {
 type RSAPSSVerifier struct{}
 
 // Verify does the actual check.
-func (v RSAPSSVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v RSAPSSVerifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	pubKey, err := getRSAPubKey(key)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (v RSAPSSVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
 // RSAPKCS1v15SVerifier checks RSA PKCS1v15 signatures
 type RSAPKCS1v15Verifier struct{}
 
-func (v RSAPKCS1v15Verifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v RSAPKCS1v15Verifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	pubKey, err := getRSAPubKey(key)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ type RSAPyCryptoVerifier struct{}
 // Verify does the actual check.
 // N.B. We have not been able to make this work in a way that is compatible
 // with PyCrypto.
-func (v RSAPyCryptoVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v RSAPyCryptoVerifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	digest := sha256.Sum256(msg)
 
 	k, _ := pem.Decode([]byte(key.Public()))
@@ -177,7 +177,7 @@ func (v RSAPyCryptoVerifier) Verify(key data.Key, sig []byte, msg []byte) error 
 type ECDSAVerifier struct{}
 
 // Verify does the actual check.
-func (v ECDSAVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v ECDSAVerifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	algorithm := key.Algorithm()
 	var pubKey crypto.PublicKey
 

--- a/signed/verifiers_test.go
+++ b/signed/verifiers_test.go
@@ -30,7 +30,7 @@ const baseECDSAx509Key = `{"keytype":"ecdsa-x509","keyval":{"public":"LS0tLS1CRU
 
 func TestRSAPSSVerifier(t *testing.T) {
 	// Unmarshal our private RSA Key
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -54,7 +54,7 @@ func TestRSAPSSVerifier(t *testing.T) {
 
 func TestRSAPSSx509Verifier(t *testing.T) {
 	// Unmarshal our public RSA Key
-	var testRSAKey data.PublicKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -74,7 +74,7 @@ func TestRSAPSSx509Verifier(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidKeyType(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -94,7 +94,7 @@ func TestRSAPSSVerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidKey(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -114,7 +114,7 @@ func TestRSAPSSVerifierWithInvalidKey(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidSignature(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -141,7 +141,7 @@ func TestRSAPSSVerifierWithInvalidSignature(t *testing.T) {
 
 func TestRSAPKCS1v15Verifier(t *testing.T) {
 	// Unmarshal our private RSA Key
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -165,7 +165,7 @@ func TestRSAPKCS1v15Verifier(t *testing.T) {
 
 func TestRSAPKCS1v15x509Verifier(t *testing.T) {
 	// Unmarshal our public RSA Key
-	var testRSAKey data.PublicKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -185,7 +185,7 @@ func TestRSAPKCS1v15x509Verifier(t *testing.T) {
 }
 
 func TestRSAPKCS1v15VerifierWithInvalidKeyType(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -205,7 +205,7 @@ func TestRSAPKCS1v15VerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestRSAPKCS1v15VerifierWithInvalidKey(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -225,7 +225,7 @@ func TestRSAPKCS1v15VerifierWithInvalidKey(t *testing.T) {
 }
 
 func TestRSAPKCS1v15VerifierWithInvalidSignature(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -251,7 +251,7 @@ func TestRSAPKCS1v15VerifierWithInvalidSignature(t *testing.T) {
 }
 
 func TestECDSAVerifier(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -273,7 +273,7 @@ func TestECDSAVerifier(t *testing.T) {
 }
 
 func TestECDSAx509Verifier(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -293,7 +293,7 @@ func TestECDSAx509Verifier(t *testing.T) {
 }
 
 func TestECDSAVerifierWithInvalidKeyType(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -313,7 +313,7 @@ func TestECDSAVerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestECDSAVerifierWithInvalidKey(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -333,7 +333,7 @@ func TestECDSAVerifierWithInvalidKey(t *testing.T) {
 }
 
 func TestECDSAVerifierWithInvalidSignature(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -358,7 +358,7 @@ func TestECDSAVerifierWithInvalidSignature(t *testing.T) {
 
 }
 
-func rsaPSSSign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
+func rsaPSSSign(privKey data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.RSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -378,7 +378,7 @@ func rsaPSSSign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) ([]by
 	return sig, nil
 }
 
-func rsaPKCS1v15Sign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
+func rsaPKCS1v15Sign(privKey data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.RSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -398,7 +398,7 @@ func rsaPKCS1v15Sign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) 
 	return sig, nil
 }
 
-func ecdsaSign(privKey *data.PrivateKey, hashed []byte) ([]byte, error) {
+func ecdsaSign(privKey data.PrivateKey, hashed []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.ECDSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -432,7 +432,7 @@ func ecdsaSign(privKey *data.PrivateKey, hashed []byte) ([]byte, error) {
 // the test
 func signX509() {
 	// Unmarshal our private RSA Key
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template

--- a/signed/verify.go
+++ b/signed/verify.go
@@ -28,7 +28,7 @@ type signedMeta struct {
 }
 
 // VerifyRoot checks if a given root file is valid against a known set of keys.
-func VerifyRoot(s *data.Signed, minVersion int, keys map[string]*data.PublicKey, threshold int) (*data.PublicKey, error) {
+func VerifyRoot(s *data.Signed, minVersion int, keys map[string]data.PublicKey, threshold int) (data.PublicKey, error) {
 	if len(s.Signatures) == 0 {
 		return nil, ErrNoSignatures
 	}

--- a/signed/verify_test.go
+++ b/signed/verify_test.go
@@ -22,7 +22,7 @@ func (VerifySuite) Test(c *C) {
 	cryptoService := NewEd25519()
 	type test struct {
 		name  string
-		keys  []data.Key
+		keys  []data.PublicKey
 		roles map[string]*data.Role
 		s     *data.Signed
 		ver   int
@@ -164,7 +164,7 @@ func (VerifySuite) Test(c *C) {
 			s := &data.Signed{Signed: b}
 			Sign(cryptoService, s, k)
 			t.s = s
-			t.keys = []data.Key{k}
+			t.keys = []data.PublicKey{k}
 		}
 		if t.roles == nil {
 			t.roles = map[string]*data.Role{

--- a/store/dbstore.go
+++ b/store/dbstore.go
@@ -82,8 +82,8 @@ func (dbs *dbStore) Commit(metafiles map[string]json.RawMessage, consistent bool
 }
 
 // GetKeys returns private keys
-func (dbs *dbStore) GetKeys(role string) ([]*data.Key, error) {
-	keys := []*data.Key{}
+func (dbs *dbStore) GetKeys(role string) ([]data.PrivateKey, error) {
+	keys := []data.PrivateKey{}
 	var r *sql.Rows
 	var err error
 	sql := "SELECT `key` FROM `keys` WHERE `role` = ? AND `namespace` = ?;"
@@ -96,7 +96,7 @@ func (dbs *dbStore) GetKeys(role string) ([]*data.Key, error) {
 	defer r.Close()
 	for r.Next() {
 		var jsonStr string
-		key := new(data.Key)
+		key := new(data.TUFKey)
 		r.Scan(&jsonStr)
 		err := json.Unmarshal([]byte(jsonStr), key)
 		if err != nil {
@@ -108,7 +108,7 @@ func (dbs *dbStore) GetKeys(role string) ([]*data.Key, error) {
 }
 
 // SaveKey saves a new private key
-func (dbs *dbStore) SaveKey(role string, key *data.Key) error {
+func (dbs *dbStore) SaveKey(role string, key data.PrivateKey) error {
 	jsonBytes, err := json.Marshal(key)
 	if err != nil {
 		return fmt.Errorf("Could not JSON Marshal Key")

--- a/store/memorystore.go
+++ b/store/memorystore.go
@@ -15,14 +15,14 @@ func MemoryStore(meta map[string]json.RawMessage, files map[string][]byte) Local
 	return &memoryStore{
 		meta:  meta,
 		files: files,
-		keys:  make(map[string][]*data.Key),
+		keys:  make(map[string][]data.PrivateKey),
 	}
 }
 
 type memoryStore struct {
 	meta  map[string]json.RawMessage
 	files map[string][]byte
-	keys  map[string][]*data.Key
+	keys  map[string][]data.PrivateKey
 }
 
 func (m *memoryStore) GetMeta(name string, size int64) (json.RawMessage, error) {
@@ -72,13 +72,13 @@ func (m *memoryStore) Commit(map[string]json.RawMessage, bool, map[string]data.H
 	return nil
 }
 
-func (m *memoryStore) GetKeys(role string) ([]*data.Key, error) {
+func (m *memoryStore) GetKeys(role string) ([]data.PrivateKey, error) {
 	return m.keys[role], nil
 }
 
-func (m *memoryStore) SaveKey(role string, key *data.Key) error {
+func (m *memoryStore) SaveKey(role string, key data.PrivateKey) error {
 	if _, ok := m.keys[role]; !ok {
-		m.keys[role] = make([]*data.Key, 0)
+		m.keys[role] = make([]data.PrivateKey, 0)
 	}
 	m.keys[role] = append(m.keys[role], key)
 	return nil


### PR DESCRIPTION
@diogomonica @endophage @NathanMcCauley

This makes it clearer whether a key is a public or private key, and uses
type safety to check that the right kind of key is being used.

We still share the same underlying structure type to store public and
private key data. But users will get a PublicKey or PrivateKey interface
type instead of the structure.

Signed-off-by: Aaron Lehmann aaron.lehmann@docker.com
