### PR TITLE
error handling on signing

### DIFF
--- a/signed/sign.go
+++ b/signed/sign.go
@@ -3,6 +3,8 @@ package signed
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/endophage/gotuf/data"
+	"github.com/endophage/gotuf/errors"
+	"fmt"
 )
 
 // Sign takes a data.Signed and a key, calculated and adds the signature
@@ -27,6 +29,12 @@ func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
 	newSigs, err := service.Sign(keyIDs, s.Signed)
 	if err != nil {
 		return err
+	}
+	if len(newSigs) < 1 {
+		return errors.ErrInsufficientSignatures{
+			Name: fmt.Sprint("Cryptoservice failed to produce any signatures for keys %v", keyIDs),
+			Err:  nil,
+		}
 	}
 	logrus.Debugf("appending %d new signatures", len(newSigs))
 	s.Signatures = append(signatures, newSigs...)


### PR DESCRIPTION
Cryptoservices can return 0 sigs for Sign. Up to callers to check for this.

Signed-off-by: Nathan McCauley nathan.mccauley@docker.com
