### PR TITLE
Fixing targets verification

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -175,19 +175,7 @@ func (c *Client) downloadRoot() error {
 	var s *data.Signed
 	var raw []byte
 	if download {
-		logrus.Debug("downloading new root")
-		raw, err = c.remote.GetMeta(role, size)
-		if err != nil {
-			return err
-		}
-		hash := sha256.Sum256(raw)
-		if expectedSha256 != nil && !bytes.Equal(hash[:], expectedSha256) {
-			// if we don't have an expected sha256, we're going to trust the root
-			// based purely on signature and expiry time validation
-			return fmt.Errorf("Remote root sha256 did not match snapshot root sha256: %#x vs. %#x", hash, []byte(expectedSha256))
-		}
-		s = &data.Signed{}
-		err = json.Unmarshal(raw, s)
+		s, err = c.downloadSigned(role, size, expectedSha256)
 		if err != nil {
 			return err
 		}
@@ -247,6 +235,8 @@ func (c Client) verifyRoot(role string, s *data.Signed, minVersion int) error {
 }
 
 // downloadTimestamp is responsible for downloading the timestamp.json
+// Timestamps are special in that we ALWAYS attempt to download and only
+// use cache if the download fails (and the cache is still valid).
 func (c *Client) downloadTimestamp() error {
 	logrus.Debug("downloadTimestamp")
 	role := data.RoleName("timestamp")
@@ -351,17 +341,7 @@ func (c *Client) downloadSnapshot() error {
 	}
 	var s *data.Signed
 	if download {
-		logrus.Debug("downloading new snapshot")
-		raw, err = c.remote.GetMeta(role, size)
-		if err != nil {
-			return err
-		}
-		genHash := sha256.Sum256(raw)
-		if !bytes.Equal(genHash[:], expectedSha256) {
-			return fmt.Errorf("Retrieved snapshot did not verify against hash in timestamp.")
-		}
-		s = &data.Signed{}
-		err = json.Unmarshal(raw, s)
+		s, err = c.downloadSigned(role, size, expectedSha256)
 		if err != nil {
 			return err
 		}
@@ -390,8 +370,7 @@ func (c *Client) downloadSnapshot() error {
 }
 
 // downloadTargets is responsible for downloading any targets file
-// including delegates roles. It will download the whole tree of
-// delegated roles below the given one
+// including delegates roles.
 func (c *Client) downloadTargets(role string) error {
 	role = data.RoleName(role) // this will really only do something for base targets role
 	snap := c.local.Snapshot.Signed
@@ -416,6 +395,24 @@ func (c *Client) downloadTargets(role string) error {
 	}
 
 	return nil
+}
+
+func (c *Client) downloadSigned(role string, size int64, expectedSha256 []byte) (*data.Signed, error) {
+	logrus.Debugf("downloading new %s", role)
+	raw, err := c.remote.GetMeta(role, size)
+	if err != nil {
+		return nil, err
+	}
+	genHash := sha256.Sum256(raw)
+	if !bytes.Equal(genHash[:], expectedSha256) {
+		return nil, ErrChecksumMismatch{role: role}
+	}
+	s := &data.Signed{}
+	err = json.Unmarshal(raw, s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (c Client) GetTargetsFile(role string, keyIDs []string, snapshotMeta data.Files, consistent bool, threshold int) (*data.Signed, error) {
@@ -454,23 +451,17 @@ func (c Client) GetTargetsFile(role string, keyIDs []string, snapshotMeta data.F
 		} else {
 			download = true
 		}
-
 	}
 
+	size := snapshotMeta[role].Length
 	var s *data.Signed
 	if download {
 		rolePath, err := c.RoleTargetsPath(role, hex.EncodeToString(expectedSha256), consistent)
 		if err != nil {
 			return nil, err
 		}
-		raw, err = c.remote.GetMeta(rolePath, snapshotMeta[role].Length)
+		s, err = c.downloadSigned(rolePath, size, expectedSha256)
 		if err != nil {
-			return nil, err
-		}
-		s = &data.Signed{}
-		err = json.Unmarshal(raw, s)
-		if err != nil {
-			logrus.Error("Error unmarshalling targets file:", err)
 			return nil, err
 		}
 	} else {

--- a/client/client.go
+++ b/client/client.go
@@ -271,7 +271,6 @@ func (c *Client) downloadTimestamp() error {
 	}
 	// unlike root, targets and snapshot, always try and download timestamps
 	// from remote, only using the cache one if we couldn't reach remote.
-	logrus.Debug("Downloading timestamp")
 	raw, err := c.remote.GetMeta(role, maxSize)
 	var s *data.Signed
 	if err != nil || len(raw) == 0 {
@@ -286,6 +285,7 @@ func (c *Client) downloadTimestamp() error {
 			}
 			return err
 		}
+		logrus.Debug("using cached timestamp")
 		s = old
 	} else {
 		download = true

--- a/client/errors.go
+++ b/client/errors.go
@@ -10,6 +10,14 @@ var (
 	ErrInsufficientKeys = errors.New("tuf: insufficient keys to meet threshold")
 )
 
+type ErrChecksumMismatch struct {
+	role string
+}
+
+func (e ErrChecksumMismatch) Error() string {
+	return fmt.Sprintf("tuf: checksum for %s did not match", e.role)
+}
+
 type ErrMissingRemoteMetadata struct {
 	Name string
 }

--- a/store/httpstore.go
+++ b/store/httpstore.go
@@ -90,6 +90,7 @@ func (s HTTPStore) GetMeta(name string, size int64) ([]byte, error) {
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrMetaNotFound{}
 	} else if resp.StatusCode != http.StatusOK {
+		logrus.Debugf("received HTTP status %d when requesting %s.", resp.StatusCode, name)
 		return nil, ErrServerUnavailable{code: resp.StatusCode}
 	}
 	if resp.ContentLength > size {


### PR DESCRIPTION
The checksum was not being verified on downloaded targets (and delegations). This PR unifies the download code for targets, snapshots and root (timestamps still has some special casing I'm looking to try and separate out).

It also adds 2 new tests to check the happy and sad paths of checksum verification.
