### PR TITLE
expectedSha256 might be nil when downloading a root. 

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -18,6 +18,14 @@ func (e ErrChecksumMismatch) Error() string {
 	return fmt.Sprintf("tuf: checksum for %s did not match", e.role)
 }
 
+type ErrMissingMeta struct {
+	role string
+}
+
+func (e ErrMissingMeta) Error() string {
+	return fmt.Sprintf("tuf: sha256 checksum required for %s", e.role)
+}
+
 type ErrMissingRemoteMetadata struct {
 	Name string
 }

--- a/store/httpstore.go
+++ b/store/httpstore.go
@@ -99,10 +99,6 @@ func (s HTTPStore) GetMeta(name string, size int64) ([]byte, error) {
 	logrus.Debugf("%d when retrieving metadata for %s", resp.StatusCode, name)
 	b := io.LimitReader(resp.Body, size)
 	body, err := ioutil.ReadAll(b)
-	if resp.ContentLength > 0 && int64(len(body)) < resp.ContentLength {
-		return nil, ErrShortRead{}
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/store/memorystore.go
+++ b/store/memorystore.go
@@ -31,7 +31,15 @@ type memoryStore struct {
 }
 
 func (m *memoryStore) GetMeta(name string, size int64) ([]byte, error) {
-	return m.meta[name], nil
+	d, ok := m.meta[name]
+	if ok {
+		if int64(len(d)) < size {
+			return d, nil
+		}
+		return d[:size], nil
+	} else {
+		return nil, ErrMetaNotFound{}
+	}
 }
 
 func (m *memoryStore) SetMeta(name string, meta []byte) error {


### PR DESCRIPTION
`downloadSigned` had removed this check, this adds it back in and also makes use of `downloadSigned` for timestamps, passing a `nil` value for `expectedSha256`

@mtrmac take a look. I'm trying to refactor the code in client/client.go as there's a lot of really similar passages, and it's pretty inscrutable right now. I really appreciate you checking it and if you have any suggestion or even PRs, please send them over.
