### PR TITLE
Don't use elliptic.P224()

### DIFF
--- a/signed/verifiers_test.go
+++ b/signed/verifiers_test.go
@@ -283,7 +283,7 @@ func TestECDSAVerifier(t *testing.T) {
 }
 
 func TestECDSAVerifierOtherCurves(t *testing.T) {
-	curves := []elliptic.Curve{elliptic.P224(), elliptic.P256(), elliptic.P384(), elliptic.P521()}
+	curves := []elliptic.Curve{elliptic.P256(), elliptic.P384(), elliptic.P521()}
 
 	for _, curve := range curves {
 		ecdsaPrivKey, err := ecdsa.GenerateKey(curve, rand.Reader)


### PR DESCRIPTION
This curve is not available on Fedora and RHEL systems, so removing the reference allows tests to pass there.  Vast majority of the curve-specific work is done in the golang crypto/elliptic package, so
this does not weaken the tests noticeably.

Signed-off-by: Miloslav Trmač mitr@redhat.com
